### PR TITLE
Adding support for non-default location of config and credential files

### DIFF
--- a/bin/switch
+++ b/bin/switch
@@ -3,9 +3,12 @@
 var inquirer = require('inquirer');
 var profile = require('../lib/profile');
 
+var fileNameEnv = process.env.AWS_CONFIG_FILE;
+var credNameEnv = process.env.AWS_SHARED_CREDENTIALS_FILE;
+
 var homeDir = (process.platform === 'win32') ? process.env.USERPROFILE : process.env.HOME;
-var fileName = homeDir + '/.aws/config';
-var credFileName = homeDir + '/.aws/credentials';
+var fileName = (fileNameEnv === undefined) ? homeDir + '/.aws/config' : fileNameEnv;
+var credFileName = (credNameEnv === undefined) ? homeDir + '/.aws/credentials' : credNameEnv;
 
 profile.getProfileNames(fileName, function (err, profiles) {
   if (err) {


### PR DESCRIPTION
### What
I've added support for non-default location of config and credential files, using the supported environment variables detailed [here](https://docs.aws.amazon.com/credref/latest/refdocs/file-location.html).

### Why
The app currently throws an error if the config and credential files are not found in the default path.

### How
If the environment variables are present, use them for the file locations. 
If not, use the default path of homedir/.aws